### PR TITLE
fix(dependabot): added explicit `patterns` definition for patch group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
       patch-dependencies:
         update-types:
           - "patch"
+        patterns:
+          - "*"
       typescript-eslint:
         patterns:
           - "@typescript-eslint*"


### PR DESCRIPTION
We are expecting this to fix the currently not being grouped named dependencies.