### PR TITLE
feat(ci/cd): Add GitHub Action for auto-assigning PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,20 @@
+name: Auto Assign
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  add_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-add-assignees@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: ${{ github.actor }}


### PR DESCRIPTION
out of the recipes from https://github.com/actions-ecosystem/recipes this sounded very interesting. As we're sometimes forgetting to set ourselves as the assignee after opening a PR, this action would be very helpful.